### PR TITLE
remove IBV_QP_INIT_ATTR_RESERVED as it was removed from rdma-core

### DIFF
--- a/libibverbscpp.h
+++ b/libibverbscpp.h
@@ -1278,7 +1278,6 @@ enum class InitAttrMask : std::underlying_type_t<ibv_qp_init_attr_mask> {
     PD = IBV_QP_INIT_ATTR_PD,
     XRCD = IBV_QP_INIT_ATTR_XRCD,
     CREATE_FLAGS = IBV_QP_INIT_ATTR_CREATE_FLAGS,
-    RESERVED = IBV_QP_INIT_ATTR_RESERVED
 };
 
 enum class CreateFlags : std::underlying_type_t<ibv_qp_create_flags> {


### PR DESCRIPTION
rdma-core seems to have removed the IBV_QP_INIT_ATTR_RESERVED enum value (58ef962809865fe58ef166e97788cc12ce8d4ecc), breaking libibverbscpp compilation. This patch removes it here too.