### PR TITLE
Wrap librdmacm similarly to libibverbs

### DIFF
--- a/libibverbscpp.cpp
+++ b/libibverbscpp.cpp
@@ -1,1 +1,2 @@
 #include "libibverbscpp.h"
+#include "librdmacmcpp.h"

--- a/librdmacmcpp.h
+++ b/librdmacmcpp.h
@@ -41,6 +41,17 @@ namespace rdma {
         static void operator delete(void *ptr) noexcept;
 
         constexpr void setContext(void *context);
+
+        void bindAddr(sockaddr *addr);
+        void resolveAddr(sockaddr *src, sockaddr *dst, int timeout_ms);
+        void resolveRoute(int timeout_ms);
+        void createQP(ibv::protectiondomain::ProtectionDomain& pd, ibv::queuepair::InitAttributes& init_attr);
+        void destroyQP();
+        void connect(rdma_conn_param* param);
+        void listen(int backlog);
+        void accept(rdma_conn_param* param);
+        void reject(void *private_data, uint8_t private_data_len);
+        void disconnect();
     };
 
     static_assert(sizeof(ID) == sizeof(rdma_cm_id), "");
@@ -154,6 +165,65 @@ inline void rdma::event::Channel::operator delete(void *ptr) noexcept {
 
 constexpr void rdma::ID::setContext(void *context) {
     this->context = context;
+}
+
+inline void rdma::ID::bindAddr(sockaddr *addr)
+{
+    int ret = rdma_bind_addr(this, addr);
+    internal::checkStatus("rdma_bind_addr", ret);
+}
+
+inline void rdma::ID::resolveAddr(sockaddr *src, sockaddr *dst, int timeout_ms)
+{
+    int ret = rdma_resolve_addr(this, src, dst, timeout_ms);
+    internal::checkStatus("rdma_resolve_addr", ret);
+}
+
+inline void rdma::ID::resolveRoute(int timeout_ms)
+{
+    int ret = rdma_resolve_route(this, timeout_ms);
+    internal::checkStatus("rdma_resolve_route", ret);
+}
+
+inline void rdma::ID::createQP(ibv::protectiondomain::ProtectionDomain& pd, ibv::queuepair::InitAttributes& init_attr)
+{
+    int ret = rdma_create_qp(this, &pd, &init_attr);
+    internal::checkStatus("rdma_create_qp", ret);
+}
+
+inline void rdma::ID::destroyQP()
+{
+    rdma_destroy_qp(this);
+}
+
+inline void rdma::ID::connect(rdma_conn_param* param)
+{
+    int ret = rdma_connect(this, param);
+    internal::checkStatus("rdma_connect", ret);
+}
+
+inline void rdma::ID::listen(int backlog)
+{
+    int ret = rdma_listen(this, backlog);
+    internal::checkStatus("rdma_listen", ret);
+}
+
+inline void rdma::ID::accept(rdma_conn_param* param)
+{
+    int ret = rdma_accept(this, param);
+    internal::checkStatus("rdma_accept", ret);
+}
+
+inline void rdma::ID::reject(void *private_data, uint8_t private_data_len)
+{
+    int ret = rdma_reject(this, private_data, private_data_len);
+    internal::checkStatus("rdma_reject", ret);
+}
+
+inline void rdma::ID::disconnect()
+{
+    int ret = rdma_disconnect(this);
+    internal::checkStatus("rdma_disconnect", ret);
 }
 
 inline void rdma::ID::operator delete(void *ptr) noexcept {

--- a/librdmacmcpp.h
+++ b/librdmacmcpp.h
@@ -1,7 +1,7 @@
 #ifndef LIBRDMACMCPP_LIBRARY_H
 #define LIBRDMACMCPP_LIBRARY_H
 
-#include <libibverbscpp.h>
+#include "libibverbscpp.h"
 #include <rdma/rdma_cma.h>
 
 namespace rdma {

--- a/librdmacmcpp.h
+++ b/librdmacmcpp.h
@@ -8,8 +8,41 @@ namespace rdma {
     namespace internal {
         using ibv::internal::exception;
         using ibv::internal::PointerOnly;
+        using ibv::internal::checkStatus;
         using ibv::internal::checkPtr;
     }
+
+    enum class PortSpace : std::underlying_type_t<rdma_port_space> {
+        TCP = RDMA_PS_TCP,
+        UDP = RDMA_PS_UDP,
+        IB = RDMA_PS_IB,
+    };
+
+    class ID : public rdma_cm_id, public internal::PointerOnly {
+        using rdma_cm_id::verbs;
+        using rdma_cm_id::channel;
+        using rdma_cm_id::context;
+        using rdma_cm_id::qp;
+        using rdma_cm_id::route;
+        using rdma_cm_id::ps;
+        using rdma_cm_id::port_num;
+        using rdma_cm_id::event;
+        using rdma_cm_id::send_cq_channel;
+        using rdma_cm_id::send_cq;
+        using rdma_cm_id::recv_cq_channel;
+        using rdma_cm_id::recv_cq;
+        using rdma_cm_id::srq;
+        using rdma_cm_id::pd;
+        using rdma_cm_id::qp_type;
+    public:
+        static void *operator new(std::size_t) noexcept = delete;
+
+        static void operator delete(void *ptr) noexcept;
+
+        constexpr void setContext(void *context);
+    };
+
+    static_assert(sizeof(ID) == sizeof(rdma_cm_id), "");
 
     class EventChannel : public rdma_event_channel, public internal::PointerOnly {
         using rdma_event_channel::fd;
@@ -17,6 +50,9 @@ namespace rdma {
         static void *operator new(std::size_t) noexcept = delete;
 
         static void operator delete(void *ptr) noexcept;
+
+	[[nodiscard]]
+	std::unique_ptr<ID> createID(void *context, PortSpace ps);
     };
 
     static_assert(sizeof(EventChannel) == sizeof(rdma_event_channel), "");
@@ -35,9 +71,25 @@ inline std::unique_ptr<rdma::EventChannel> rdma::createEventChannel() {
     return std::unique_ptr<EC>(reinterpret_cast<EC *>(eventChannel));
 }
 
+inline std::unique_ptr<rdma::ID>
+rdma::EventChannel::createID(void *context, PortSpace ps)
+{
+    rdma_cm_id *id;
+    int ret = rdma_create_id(this, &id, context, static_cast<rdma_port_space>(ps));
+    internal::checkStatus("rdma_create_id", ret);
+    return std::unique_ptr<ID>(reinterpret_cast<ID *>(id));
+}
+
 inline void rdma::EventChannel::operator delete(void *ptr) noexcept {
     rdma_destroy_event_channel(reinterpret_cast<rdma_event_channel *>(ptr));
 }
 
+constexpr void rdma::ID::setContext(void *context) {
+    this->context = context;
+}
+
+inline void rdma::ID::operator delete(void *ptr) noexcept {
+    rdma_destroy_id(reinterpret_cast<rdma_cm_id *>(ptr));
+}
 
 #endif

--- a/librdmacmcpp.h
+++ b/librdmacmcpp.h
@@ -1,0 +1,43 @@
+#ifndef LIBRDMACMCPP_LIBRARY_H
+#define LIBRDMACMCPP_LIBRARY_H
+
+#include <libibverbscpp.h>
+#include <rdma/rdma_cma.h>
+
+namespace rdma {
+    namespace internal {
+        using ibv::internal::exception;
+        using ibv::internal::PointerOnly;
+        using ibv::internal::checkPtr;
+    }
+
+    class EventChannel : public rdma_event_channel, public internal::PointerOnly {
+        using rdma_event_channel::fd;
+    public:
+        static void *operator new(std::size_t) noexcept = delete;
+
+        static void operator delete(void *ptr) noexcept;
+    };
+
+    static_assert(sizeof(EventChannel) == sizeof(rdma_event_channel), "");
+
+    std::unique_ptr<EventChannel> createEventChannel();
+
+/**********************************************************************************************************************/
+} // namespace rdma
+
+inline std::unique_ptr<rdma::EventChannel> rdma::createEventChannel() {
+    using EC = rdma::EventChannel;
+    const auto eventChannel = rdma_create_event_channel();
+    if (eventChannel == nullptr && errno == ENODEV)
+        throw internal::exception("rdma_create_event_channel - No RDMA devices were detected", errno);
+    internal::checkPtr("rdma_create_event_channel", eventChannel);
+    return std::unique_ptr<EC>(reinterpret_cast<EC *>(eventChannel));
+}
+
+inline void rdma::EventChannel::operator delete(void *ptr) noexcept {
+    rdma_destroy_event_channel(reinterpret_cast<rdma_event_channel *>(ptr));
+}
+
+
+#endif


### PR DESCRIPTION
I have tried to wrap (the important parts of) librdmacm similarly to how libibverbs is wrapped, so that it can be used in C++ with RAII and work together with the libibverbs wrappers.