### PR TITLE
librdmacm example

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -10,3 +10,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic ${WARNINGS}")
 add_executable(example example.cpp)
 target_include_directories(example SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(example ibverbs)
+
+add_executable(rdmacm_client rdmacm_client.cpp)
+target_include_directories(rdmacm_client SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(rdmacm_client ibverbs rdmacm)
+
+add_executable(rdmacm_server rdmacm_server.cpp)
+target_include_directories(rdmacm_server SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(rdmacm_server ibverbs rdmacm)

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -15,11 +15,11 @@ QpInitAttr setupQpInitAttr(ibv::completions::CompletionQueue &sendCompletionQueu
     //queuePairAttributes.setSharedReceiveQueue(receiveQueue); // not needed
     // Capabilities can be queried with ctx->queryAttributes()
     init.capabilities = std::make_unique<ibv::queuepair::Capabilities>();
-    init.capabilities->max_send_wr = 16351;
-    init.capabilities->max_recv_wr = 16351;
-    init.capabilities->max_send_sge = 1;
-    init.capabilities->max_recv_sge = 1;
-    init.capabilities->max_inline_data = 512;
+    init.capabilities->setMaxSendWr(16351);
+    init.capabilities->setMaxRecvWr(16351);
+    init.capabilities->setMaxSendSge(1);
+    init.capabilities->setMaxRecvSge(1);
+    init.capabilities->setMaxInlineData(512);
     init.queuePairAttributes->setCapabilities(*init.capabilities);
     init.queuePairAttributes->setType(ibv::queuepair::Type::RC);
     init.queuePairAttributes->setSignalAll(true);

--- a/example/rdmacm_client.cpp
+++ b/example/rdmacm_client.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the OpenIB.org BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <netdb.h>
+#include <errno.h>
+#include <getopt.h>
+#include <librdmacmcpp.h>
+
+static const char *server = "127.0.0.1";
+static const char *port = "7471";
+
+static void run(void)
+{
+	bool inlineFlag;
+	static uint8_t send_msg[16];
+	static uint8_t recv_msg[16];
+
+	struct rdma_addrinfo hints;
+
+	memset(&hints, 0, sizeof hints);
+	hints.ai_port_space = RDMA_PS_TCP;
+	auto res = rdma::addrinfo::get(server, port, &hints);
+
+	ibv::queuepair::InitAttributes attr;
+	memset(&attr, 0, sizeof(attr));
+	ibv::queuepair::Capabilities cap;
+	cap.setMaxSendWr(1);
+	cap.setMaxRecvWr(1);
+	cap.setMaxSendSge(1);
+	cap.setMaxRecvSge(1);
+	cap.setMaxInlineData(16);
+	attr.setCapabilities(cap);
+	attr.setSignalAll(1);
+	auto id = rdma::createEP(res, NULL, boost::make_optional(attr));
+	// Check to see if we got inline data allowed or not
+	if (attr.getCapabilities().getMaxInlineData() >= 16)
+		inlineFlag = true;
+	else
+		printf("rdma_client: device doesn't support IBV_SEND_INLINE, "
+		       "using sge sends\n");
+
+	auto mr = id->getPD()->registerMemoryRegion(recv_msg, 16,
+						    { ibv::AccessFlag::LOCAL_WRITE });
+	auto send_mr = id->getPD()->registerMemoryRegion(send_msg, 16, {});
+
+	auto qp = id->getQP();
+	auto recv_wr = ibv::workrequest::Simple<ibv::workrequest::Recv>();
+	recv_wr.setLocalAddress(mr->getSlice());
+	ibv::workrequest::Recv *bad_recv_wr;
+	qp->postRecv(recv_wr, bad_recv_wr);
+	id->connect(nullptr);
+
+	auto wr = ibv::workrequest::Simple<ibv::workrequest::Send>();
+	ibv::workrequest::SendWr *bad_wr;
+	wr.setLocalAddress(send_mr->getSlice());
+	if (inlineFlag) {
+		wr.setFlags({ ibv::workrequest::Flags::INLINE });
+	}
+	qp->postSend(wr, bad_wr);
+
+	ibv::workcompletion::WorkCompletion wc;
+	auto send_cq = qp->getSendCQ();
+	while ((send_cq->poll(1, &wc)) == 0);
+
+	auto recv_cq = id->getQP()->getRecvCQ();
+	while ((recv_cq->poll(1, &wc)) == 0);
+
+	id->disconnect();
+}
+
+int main(int argc, char **argv)
+{
+	int op;
+
+	while ((op = getopt(argc, argv, "s:p:")) != -1) {
+		switch (op) {
+		case 's':
+			server = optarg;
+			break;
+		case 'p':
+			port = optarg;
+			break;
+		default:
+			printf("usage: %s\n", argv[0]);
+			printf("\t[-s server_address]\n");
+			printf("\t[-p port_number]\n");
+			exit(1);
+		}
+	}
+
+	printf("rdma_client: start\n");
+	run();
+	printf("rdma_client: end\n");
+	return 0;
+}

--- a/example/rdmacm_server.cpp
+++ b/example/rdmacm_server.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2005-2009 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the OpenIB.org BSD license
+ * below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <getopt.h>
+#include <netdb.h>
+#include <librdmacmcpp.h>
+
+static const char *server = "0.0.0.0";
+static const char *port = "7471";
+
+static int run(void)
+{
+	struct rdma_addrinfo hints;
+	ibv::queuepair::Attributes qp_attr;
+	ibv::workcompletion::WorkCompletion wc;
+	bool inlineFlag = false;
+
+	uint8_t send_msg[16];
+	uint8_t recv_msg[16];
+
+	memset(&hints, 0, sizeof hints);
+	hints.ai_flags = RAI_PASSIVE;
+	hints.ai_port_space = RDMA_PS_TCP;
+	auto res = rdma::addrinfo::get(server, port, &hints);
+
+	ibv::queuepair::InitAttributes init_attr;
+	memset(&init_attr, 0, sizeof init_attr);
+	ibv::queuepair::Capabilities cap;
+	cap.setMaxSendWr(1);
+	cap.setMaxRecvWr(1);
+	cap.setMaxSendSge(1);
+	cap.setMaxRecvSge(1);
+	cap.setMaxInlineData(16);
+	init_attr.setCapabilities(cap);
+	init_attr.setSignalAll(1);
+	auto listen_id = rdma::createEP(res, NULL, boost::make_optional(init_attr));
+	listen_id->listen(0);
+	auto id = listen_id->getRequest();
+
+	memset(&qp_attr, 0, sizeof qp_attr);
+	memset(&init_attr, 0, sizeof init_attr);
+	id->getQP()->query(qp_attr, {ibv::queuepair::AttrMask::CAP},  init_attr, {});
+	if (init_attr.getCapabilities().getMaxInlineData() >= 16)
+		inlineFlag = true;
+	else
+		printf("rdma_server: device doesn't support IBV_SEND_INLINE, "
+		       "using sge sends\n");
+
+	auto mr = id->getPD()->registerMemoryRegion(recv_msg, 16,
+						    { ibv::AccessFlag::LOCAL_WRITE });
+	auto send_mr = id->getPD()->registerMemoryRegion(send_msg, 16, {});
+
+	auto qp = id->getQP();
+	auto recv_wr = ibv::workrequest::Simple<ibv::workrequest::Recv>();
+	recv_wr.setLocalAddress(mr->getSlice());
+	ibv::workrequest::Recv *bad_recv_wr;
+	qp->postRecv(recv_wr, bad_recv_wr);
+	id->accept(nullptr);
+
+	auto recv_cq = id->getQP()->getRecvCQ();
+	while ((recv_cq->poll(1, &wc)) == 0);
+
+	auto wr = ibv::workrequest::Simple<ibv::workrequest::Send>();
+	ibv::workrequest::SendWr *bad_wr;
+	wr.setLocalAddress(send_mr->getSlice());
+	if (inlineFlag) {
+		wr.setFlags({ ibv::workrequest::Flags::INLINE });
+	}
+	qp->postSend(wr, bad_wr);
+
+	auto send_cq = qp->getSendCQ();
+	while ((send_cq->poll(1, &wc)) == 0);
+
+	id->disconnect();
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	int op;
+
+	while ((op = getopt(argc, argv, "s:p:")) != -1) {
+		switch (op) {
+		case 's':
+			server = optarg;
+			break;
+		case 'p':
+			port = optarg;
+			break;
+		default:
+			printf("usage: %s\n", argv[0]);
+			printf("\t[-s server_address]\n");
+			printf("\t[-p port_number]\n");
+			exit(1);
+		}
+	}
+
+	printf("rdma_server: start\n");
+	run();
+	printf("rdma_server: end\n");
+	return 0;
+}

--- a/libibverbscpp.h
+++ b/libibverbscpp.h
@@ -1596,6 +1596,7 @@ class InitAttributes : public ibv_qp_init_attr {
 
     constexpr void setSharedReceiveQueue(srq::SharedReceiveQueue &sharedReceiveQueue);
 
+    constexpr const Capabilities& getCapabilities() const;
     constexpr void setCapabilities(const Capabilities &caps);
 
     constexpr void setType(Type type);
@@ -1680,6 +1681,9 @@ class QueuePair : public ibv_qp, public internal::PointerOnly {
     void attachToMcastGroup(const Gid &gid, uint16_t lid);
 
     void detachFromMcastGroup(const Gid &gid, uint16_t lid);
+
+    ibv::completions::CompletionQueue *getRecvCQ();
+    ibv::completions::CompletionQueue *getSendCQ();
 };
 
 static_assert(sizeof(QueuePair) == sizeof(ibv_qp), "");
@@ -3187,6 +3191,10 @@ constexpr void ibv::queuepair::InitAttributes::setSharedReceiveQueue(ibv::srq::S
     srq = &sharedReceiveQueue;
 }
 
+constexpr const ibv::queuepair::Capabilities& ibv::queuepair::InitAttributes::getCapabilities() const {
+    return reinterpret_cast<const Capabilities&>(cap);
+}
+
 constexpr void ibv::queuepair::InitAttributes::setCapabilities(const ibv::queuepair::Capabilities &caps) {
     cap = caps;
 }
@@ -3287,6 +3295,14 @@ inline void ibv::queuepair::QueuePair::attachToMcastGroup(const ibv::Gid &gid, u
 inline void ibv::queuepair::QueuePair::detachFromMcastGroup(const ibv::Gid &gid, uint16_t lid) {
     const auto status = ibv_detach_mcast(this, &gid.underlying, lid);
     internal::checkStatus("ibv_detach_mcast", status);
+}
+
+inline ibv::completions::CompletionQueue *ibv::queuepair::QueuePair::getRecvCQ() {
+    return reinterpret_cast<ibv::completions::CompletionQueue *>(recv_cq);
+}
+
+inline ibv::completions::CompletionQueue *ibv::queuepair::QueuePair::getSendCQ() {
+    return reinterpret_cast<ibv::completions::CompletionQueue *>(send_cq);
 }
 
 constexpr ibv::event::Type ibv::event::AsyncEvent::getType() const {


### PR DESCRIPTION
Hi,

Here's an example application which uses the rdmacm C++ wrappers. The code is based on the C examples rdma_client/rdma_server from librdmacm itself. To port the example with minimal changes I also added a few missing wrappers.